### PR TITLE
require node 16 as adapter-core 3.x.x is used

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "type": "git",
     "url": "https://github.com/PLCHome/ioBroker.growatt"
   },
+  "engines": {
+    "node": ">=16"
+  },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.3",
     "growatt": "^0.7.1"


### PR DESCRIPTION
adapter-core 3.x.x is known to fail when installed at node 14 or earlier as npm 7 does not install peerDependencies. So this adapter requires node 16 or newer.